### PR TITLE
add css for embedly and about content

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -23,3 +23,19 @@
  .nav {
     margin-top: 35px;
  }
+
+ .thumbnail {
+    position: relative;
+    padding-bottom: 67.5%;
+    height: 0;
+    margin: 10px 0;
+    overflow: hidden;
+ }
+
+ .image_tag {
+    position: absolute;
+    top: 0;
+    left: 0;
+    width: 100%;
+    height: 100%
+ }

--- a/app/views/topics/index.html.erb
+++ b/app/views/topics/index.html.erb
@@ -21,6 +21,7 @@
                   <% topic.bookmarks.each do |bookmark| %>
                     <div class="thumbnail">
                       <img src="" alt="...">
+                      <%= link_to bookmark.url, bookmark.url, :target => '_blank' %>
 
                       <% embedly = display(bookmark.url) %>
                       <%= link_to embedly[:url], :target => '_blank' do %>

--- a/app/views/welcome/about.html.erb
+++ b/app/views/welcome/about.html.erb
@@ -1,2 +1,15 @@
+<br>
+<div class="jumbotron">
+
 <h1>About Blocmark</h1>
 <p>Created by Pam</p>
+
+</br>
+
+<h2>Just send an email to:</br> <strong>pam-blocmarks@app5988cc52158c402ab5689904615024dc.mailgun.org<strong></h2> <h3>with Topic in the subject line and your bookmark url in the body of the email.</h3> 
+
+</br>
+
+<h3>Your Topic and bookmark will appear on "Your Bookmarks". You can "like" your bookmarks and other people's bookmarks. You can add Topics and new bookmarks on the site or email them using the above address.</h3>
+
+</div>


### PR DESCRIPTION
Added CSS to embedly to make it look uniform, added content to About page - everything seems to be working. Emailed a new topic - shoes - to site on heroku with a url and it worked. But embedly isn't showing up on heroku site so need to fix this. Ready to merge.
